### PR TITLE
new dataframe ouputs, predict and predict_proba methods in ModelEvaluation

### DIFF
--- a/palma/base/model.py
+++ b/palma/base/model.py
@@ -10,6 +10,8 @@
 # limitations under the License.
 
 from datetime import datetime
+import numpy as np
+import pandas as pd
 
 from palma.base.project import Project
 from palma.components.base import Component
@@ -52,7 +54,10 @@ class ModelEvaluation:
         self.predictions_ = self.__compute_predictions(
             project, project.validation_strategy.indexes_train_test, self.all_estimators_)
         self.predictions_val_ = self.__compute_predictions(
-            project, project.validation_strategy.indexes_val, self.all_estimators_val_)
+            project, project.validation_strategy.indexes_val, self.all_estimators_val_, val=True)
+
+        self.__project = project
+        self.__all_estimators = self.all_estimators_
 
         for name, comp in self.__components.items():
             comp(project, self)
@@ -68,19 +73,167 @@ class ModelEvaluation:
         avg_estimator = AverageEstimator(est)
         return est, avg_estimator
 
-    def __compute_predictions(self, project, indexes, estimators):
+    def __compute_predictions(self, project, indexes, estimators, val=False):
         predictions = {}
+        n_y = project.y.shape[0]
+        n_class = project.y.unique().shape[0]
+        record_split_type = pd.Series(np.zeros(n_y))
+        record_split_type = record_split_type.astype(str)
+        record_split_type.loc[:] = ""
+        # ------------------- predict -----------------------
+        if val:
+            self.__val_predict_df = pd.Series(np.zeros(n_y))
+        else:
+            self.__predict_df = pd.Series(np.zeros(n_y))
+            self.__predict_df = pd.Series(np.zeros(n_y))
+        # ---------------- predict_proba --------------------
+        est = estimators[0]
+        if hasattr(est, "predict_proba"):
+            if val:
+                self.__val_predict_proba_df = pd.DataFrame(np.zeros((n_y, n_class)))
+            else:
+                self.__predict_proba_df = pd.DataFrame(np.zeros((n_y, n_class)))
+                self.__predict_proba_df = self.__predict_proba_df.copy()
+        # ============== COMPUTE PREDICTIONS ===============
         for i, (train, test) in enumerate(indexes):
+            if val:
+                record_split_type.loc[train] += "."
+            else:
+                record_split_type.loc[train] += "train"
+            record_split_type.loc[test] += "test"
             est = estimators[i]
             if hasattr(est, "predict_proba"):
-                predict_train = est.predict_proba(project.X.iloc[train])[:, 1]
-                predict_test = est.predict_proba(project.X.iloc[test])[:, 1]
+                pred_train = est.predict_proba(project.X.iloc[train])
+                pred_test = est.predict_proba(project.X.iloc[test])
+                predict_train = pred_train[:, 1]
+                predict_test = pred_test[:, 1]
+                if val:
+                    # ---------------- predict_proba --------------------
+                    self.__val_predict_proba_df.loc[train, :] = pred_train
+                    self.__val_predict_proba_df.loc[test, :] = pred_test
+                    # -------------------- predict ----------------------
+                    self.__val_predict_df.loc[train] = est.predict(project.X.iloc[train])
+                    self.__val_predict_df.loc[test] = est.predict(project.X.iloc[test])
+                else:
+                    # ---------------- predict_proba --------------------
+                    self.__predict_proba_df.loc[train, :] = pred_train
+                    self.__predict_proba_df.loc[test, :] = pred_test
+                    # -------------------- predict ----------------------
+                    self.__predict_df.loc[train] = est.predict(project.X.iloc[train])
+                    self.__predict_df.loc[test] = est.predict(project.X.iloc[test])
             else:
+                # -------------------- predict ----------------------
                 predict_train = est.predict(project.X.iloc[train])
                 predict_test = est.predict(project.X.iloc[test])
-
+                if val:
+                    self.__val_predict_df.loc[train] = predict_train
+                    self.__val_predict_df.loc[test] = predict_test
+                else:
+                    self.__predict_df.loc[train] = predict_train
+                    self.__predict_df.loc[test] = predict_test
             predictions[i] = dict(train=predict_train, test=predict_test)
+        # =============== final formatting =============
+        if val:
+            self.__val_predict_df = self.__val_predict_df.to_frame()
+            self.__val_predict_df["split_type"] = record_split_type
+            self.__val_predict_df.index = project.y.index
+        else:
+            self.__predict_df = self.__predict_df.to_frame()
+            self.__predict_df["split_type"] = record_split_type
+            self.__predict_df.index = project.y.index
+        if hasattr(est, "predict_proba"):
+            if val:
+                self.__val_predict_proba_df["split_type"] = record_split_type
+                self.__val_predict_proba_df.index = project.y.index
+            else:
+                self.__predict_proba_df["split_type"] = record_split_type
+                self.__predict_proba_df.index = project.y.index
+        else:
+            self.__predict_proba_df = None
+            self.__val_predict_proba_df = None
         return predictions
+
+    def predict(self, X, return_df=False):
+        """
+        Mimic sklearn predict method. Note that contrary to fit,
+        This function does not perform cross validation prediction
+        nor does it train the estimators.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            Samples.
+        return_df : True = returns pd.Series, False = return np.array.
+
+        Returns
+        -------
+        C : array, shape (n_samples,) or pandas series, shape (n_samples)
+            or None if unmatched features with train dataframe.
+            Returns predicted values.
+        """
+        returned_obj = None
+        if f"{list(X.columns)}" != f"{list(self.__project.X.columns)}":
+            print("Error: The dataframe doesn't have the same number of predictors or the same"
+                  " column labels as the train dataframe.")
+        else:
+            print("Warning: Fit method has already created train, validation and test predictions"
+                  " based on the project data. Make sure that running predict is relevant in your case,"
+                  " such as for testing new data. Predictions from fitted object can be accessed"
+                  " by calling the following attributes: .predictions_, .predict_df, .val_predict_df")
+            n_y = self.__project.y.shape[0]
+            self.__predict_df = pd.Series(np.zeros(n_y))
+            self.__predict_proba_df = None
+            n_est = len(self.__all_estimators)
+            for est in self.__all_estimators:
+                # -------------------- predict ----------------------
+                predict_test = est.predict(X)
+                self.__predict_df += predict_test/n_est
+            self.__predict_df.index = self.__project.y.index
+            if not return_df: returned_obj = self.__predict_df.values
+            else: returned_obj = self.__predict_df
+        return returned_obj
+
+    def predict_proba(self, X, return_df=False):
+        """
+        Mimic sklearn predict_proba method. Note that contrary to fit,
+        This function does not perform cross validation prediction
+        nor does it train the estimators.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            Samples.
+        return_df : True = returns pd.Dataframe, False = return np.array.
+
+        Returns
+        -------
+        C : array, shape (n_samples, n_features)
+            or pandas dataframe, shape (n_samples, n_features)
+            or None if unmatched features with train dataframe.
+            Returns predicted probabilities.
+        """
+        returned_obj = None
+        if f"{list(X.columns)}" != f"{list(self.__project.X.columns)}":
+            print("Error: The dataframe doesn't have the same number of predictors or the same"
+                  " column labels as the train dataframe.")
+        else:
+            print("Warning: Fit method has already created train, validation and test predictions"
+                  " based on the project data. Make sure that running predict_proba is relevant in your case,"
+                  " such as for testing new data. Predictions from fitted object can be accessed"
+                  " by calling the following attributes: .predictions_, .predict_proba_df, .val_predict_proba_df")
+            n_y = self.__project.y.shape[0]
+            n_class = self.__project.y.unique().shape[0]
+            self.__predict_proba_df = pd.DataFrame(np.zeros((n_y,n_class)))
+            self.__predict_proba_df.index = self.__project.y.index
+            self.__predict_df = None
+            # ============== COMPUTE PREDICTIONS ===============
+            n_est = len(self.__all_estimators)
+            for est in self.__all_estimators:
+                predict_test = est.predict_proba(X)
+                self.__predict_proba_df += predict_test / n_est
+            if not return_df: returned_obj = self.__predict_proba_df.values
+            else: returned_obj = self.__predict_proba_df
+        return returned_obj
 
     @property
     def id(self) -> str:
@@ -94,3 +247,22 @@ class ModelEvaluation:
     def unfit_estimator(self):
         return self.__estimator
 
+    @property
+    def predict_df(self) -> pd.Series:
+        return self.__predict_df
+
+    @property
+    def val_predict_df(self) -> pd.Series:
+        return self.__val_predict_df
+
+    @property
+    def predict_proba_df(self) -> pd.DataFrame:
+        if hasattr(self, "_ModelEvaluation__predict_proba_df"): df = self.__predict_proba_df
+        else: df = None
+        return df
+
+    @property
+    def val_predict_proba_df(self) -> pd.DataFrame:
+        if hasattr(self, "_ModelEvaluation__val_predict_proba_df"):df = self.__val_predict_proba_df
+        else: df = None
+        return df

--- a/tests/test_component/test_logger.py
+++ b/tests/test_component/test_logger.py
@@ -146,3 +146,29 @@ def test_artifact_logging():
     logger.logger.log_metrics({'a': 1}, "metric")
     logger.logger.log_artifact(fig, "figure")
 
+
+def test_fit_dataframe_outputs(learning_data):
+    _, learn, X, y = learning_data
+    assert learn.predict_df.shape[1] == 2
+    assert learn.val_predict_df.shape[1] == 2
+    assert learn.predict_proba_df.shape[1] > 2
+    assert learn.val_predict_proba_df.shape[1] > 2
+
+
+def test_fit_predict_predict_proba(learning_data):
+    _, learn, X, y = learning_data
+    y_pred = learn.predict(X)
+    y_pred_proba = learn.predict_proba(X, return_df=True)
+    assert len(y_pred.shape) == 1
+    assert y_pred_proba.shape[1] >= 2
+
+
+def test_fit_predict_failure(learning_data):
+    _, learn, X, y = learning_data
+    Xbis = pd.concat([X,y], axis = 1)
+    y_pred = learn.predict(Xbis)
+    y_pred_proba = learn.predict_proba(Xbis, return_df=True)
+    assert y_pred is None
+    assert y_pred_proba is None
+
+


### PR DESCRIPTION
Three modifications:
1) The predictions are now also stored in private attributes as dataframes, and can be accessed with the getters: "predict_df", "predict_proba_df", "val_predict_df", "val_predict_proba_df".
2) Implementation of predict and predict_proba methods to test new data. These functions return either array as done by sklearn predict and sklearn predict_proba. They can also return dataframes if argument return_df is set to True (default to False). These functions overwright the previously listed dataframes.
3) 3 tests added to test the correct functionning of these features.